### PR TITLE
Fix vulnerability in QEMU library

### DIFF
--- a/hw/net/pcnet.c
+++ b/hw/net/pcnet.c
@@ -1007,14 +1007,14 @@ ssize_t pcnet_receive(NetClientState *nc, const uint8_t *buf, size_t size_)
     uint8_t buf1[60];
     int remaining;
     int crc_err = 0;
-    int size = size_;
+    size_t size = size_;
 
     if (CSR_DRX(s) || CSR_STOP(s) || CSR_SPND(s) || !size ||
         (CSR_LOOP(s) && !s->looptest)) {
         return -1;
     }
 #ifdef PCNET_DEBUG
-    printf("pcnet_receive size=%d\n", size);
+    printf("pcnet_receive size=%zu\n", size);
 #endif
 
     /* if too small buffer, then expand it */


### PR DESCRIPTION
fixes a buffer overflow vulnerability in QEMU library.

disclaimer: this pr is part of a class assignment so feel free to do with it what you will.

see: https://davidalanreid.github.io/output/b1d80d12c5f7ff081bb80ab4f4241d4248691192/index.html
https://lists.gnu.org/archive/html/qemu-devel/2018-09/msg03268.html